### PR TITLE
fix bug: unable to fetch seqno 0

### DIFF
--- a/ton-index-postgres-v2/src/IndexScheduler.h
+++ b/ton-index-postgres-v2/src/IndexScheduler.h
@@ -27,7 +27,7 @@ private:
   std::shared_ptr<td::Destructor> watcher_;
 
   std::uint32_t max_active_tasks_{32};
-  std::int32_t last_known_seqno_{0};
+  std::int32_t last_known_seqno_{-1};
   std::int32_t last_indexed_seqno_{0};
   std::int32_t from_seqno_{0};
   std::int32_t to_seqno_{0};


### PR DESCRIPTION
At the initial time, last_known_seqno_ is equal to 0, and in the [got_last_known_seqno](https://github.com/toncenter/ton-index-worker/blob/main/ton-index-postgres-v2/src/IndexScheduler.cpp#L111) function, last_known_seqno_ will be increased by 1 each time, causing seqno always start from 1.

In addition, in [TraceAssembler::process_queue](https://github.com/toncenter/ton-index-worker/blob/main/tondb-scanner/src/TraceAssembler.cpp#L146), when from_seqno_ is set to 0, expected_seqno_ is also 0, but the blocks will only be fetched starting from 1, causing the program to get stuck.
