### PR TITLE
Update README.md and add2systemd.sh to only install the ton-index-pos…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.16)
 
 project(ton-index-cpp)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(PGTON "Enable adding the pgton subdirectory" OFF)
 option(TON_USE_JEMALLOC "Use \"ON\" to enable JeMalloc." OFF)
 

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ Do the following steps to build and run index worker from source.
 
 1. Install required packages: 
 
-        sudo apt-get update -y
-        sudo apt-get install -y build-essential cmake clang openssl libssl-dev zlib1g-dev gperf wget git curl libreadline-dev ccache libmicrohttpd-dev pkg-config libsecp256k1-dev libsodium-dev python3-dev libpq-dev ninja-build
+        sudo apt update -y
+        sudo apt install -y build-essential cmake clang openssl libssl-dev zlib1g-dev gperf wget git curl libreadline-dev ccache libmicrohttpd-dev liblz4-dev pkg-config libsecp256k1-dev libsodium-dev python3-dev libpq-dev ninja-build
 2. Build TON index worker binary:
 
         mkdir -p build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -GNinja ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=off -GNinja ..
         ninja -j$(nproc) ton-index-postgres-v2
 
 3. Install binary to your system:
 
-        sudo cmake --install 
+        sudo cmake --install ./ton-index-postgres-v2/
 
 4. Increase maximum opened files limit: 
 

--- a/scripts/add2systemd.sh
+++ b/scripts/add2systemd.sh
@@ -48,7 +48,7 @@ else
     mkdir -p build
     cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=off -GNinja -S . -B ./build
     ninja -C ./build -j$(nproc) ton-index-postgres-v2
-    sudo cmake --install build/
+    sudo cmake --install ./build/ton-index-postgres-v2
 fi
 
 # setup daemon

--- a/ton-index-postgres/src/InsertManagerPostgres.cpp
+++ b/ton-index-postgres/src/InsertManagerPostgres.cpp
@@ -200,7 +200,7 @@ std::string InsertBatchPostgres::jsonify(const schema::SplitMergeInfo& info) {
 }
 
 
-std::string InsertBatchPostgres::jsonify(const schema::StorageUsedShort& s) {
+std::string InsertBatchPostgres::jsonify(const schema::StorageUsed& s) {
   auto jb = td::JsonBuilder();
   auto c = jb.enter_object();
   c("cells", std::to_string(s.cells));

--- a/ton-index-postgres/src/InsertManagerPostgres.h
+++ b/ton-index-postgres/src/InsertManagerPostgres.h
@@ -55,7 +55,7 @@ private:
   std::string stringify(schema::AccStatusChange acc_status_change);
   std::string stringify(schema::AccountStatus account_status);
   std::string jsonify(const schema::SplitMergeInfo& info);
-  std::string jsonify(const schema::StorageUsedShort& s);
+  std::string jsonify(const schema::StorageUsed& s);
   std::string jsonify(const schema::TrStoragePhase& s);
   std::string jsonify(const schema::TrCreditPhase& c);
   std::string jsonify(const schema::TrActionPhase& action);

--- a/tondb-scanner/src/DataParser.cpp
+++ b/tondb-scanner/src/DataParser.cpp
@@ -292,12 +292,12 @@ td::Result<schema::TrComputePhase> ParseQuery::parse_tr_compute_phase(vm::CellSl
   return td::Status::OK();
 }
 
-td::Result<schema::StorageUsedShort> ParseQuery::parse_storage_used_short(vm::CellSlice& cs) {
-  block::gen::StorageUsedShort::Record info;
+td::Result<schema::StorageUsed> ParseQuery::parse_storage_used(vm::CellSlice& cs) {
+  block::gen::StorageUsed::Record info;
   if (!tlb::unpack(cs, info)) {
     return td::Status::Error("Error unpacking StorageUsedShort");
   }
-  schema::StorageUsedShort res;
+  schema::StorageUsed res;
   res.bits = block::tlb::t_VarUInteger_7.as_uint(*info.bits);
   res.cells = block::tlb::t_VarUInteger_7.as_uint(*info.cells);
   return res;
@@ -331,7 +331,7 @@ td::Result<schema::TrActionPhase> ParseQuery::parse_tr_action_phase(vm::CellSlic
   res.skipped_actions = info.skipped_actions;
   res.msgs_created = info.msgs_created;
   res.action_list_hash = info.action_list_hash;
-  TRY_RESULT_ASSIGN(res.tot_msg_size, parse_storage_used_short(info.tot_msg_size.write()));
+  TRY_RESULT_ASSIGN(res.tot_msg_size, parse_storage_used(info.tot_msg_size.write()));
   return res;
 }
 
@@ -351,7 +351,7 @@ td::Result<schema::TrBouncePhase> ParseQuery::parse_tr_bounce_phase(vm::CellSlic
         return td::Status::Error("Error unpacking tr_phase_bounce_nofunds");
       }
       schema::TrBouncePhase_nofunds res;
-      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used_short(nofunds.msg_size.write()));
+      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used(nofunds.msg_size.write()));
       TRY_RESULT_ASSIGN(res.req_fwd_fees, convert::to_balance(nofunds.req_fwd_fees));
       return res;
     }
@@ -361,7 +361,7 @@ td::Result<schema::TrBouncePhase> ParseQuery::parse_tr_bounce_phase(vm::CellSlic
         return td::Status::Error("Error unpacking tr_phase_bounce_ok");
       }
       schema::TrBouncePhase_ok res;
-      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used_short(ok.msg_size.write()));
+      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used(ok.msg_size.write()));
       TRY_RESULT_ASSIGN(res.msg_fees, convert::to_balance(ok.msg_fees));
       TRY_RESULT_ASSIGN(res.fwd_fees, convert::to_balance(ok.fwd_fees));
       return res;

--- a/tondb-scanner/src/DataParser.h
+++ b/tondb-scanner/src/DataParser.h
@@ -24,7 +24,7 @@ private:
   td::Result<schema::TrStoragePhase> parse_tr_storage_phase(vm::CellSlice& cs);
   td::Result<schema::TrCreditPhase> parse_tr_credit_phase(vm::CellSlice& cs);
   td::Result<schema::TrComputePhase> parse_tr_compute_phase(vm::CellSlice& cs);
-  td::Result<schema::StorageUsedShort> parse_storage_used_short(vm::CellSlice& cs);
+  td::Result<schema::StorageUsed> parse_storage_used(vm::CellSlice& cs);
   td::Result<schema::TrActionPhase> parse_tr_action_phase(vm::CellSlice& cs);
   td::Result<schema::TrBouncePhase> parse_tr_bounce_phase(vm::CellSlice& cs);
   td::Result<schema::SplitMergeInfo> parse_split_merge_info(td::Ref<vm::CellSlice>& cs);

--- a/tondb-scanner/src/IndexData.h
+++ b/tondb-scanner/src/IndexData.h
@@ -67,7 +67,7 @@ struct TrComputePhase_vm {
 using TrComputePhase = std::variant<TrComputePhase_skipped, 
                                     TrComputePhase_vm>;
 
-struct StorageUsedShort {
+struct StorageUsed {
   uint64_t cells;
   uint64_t bits;
 };
@@ -86,19 +86,19 @@ struct TrActionPhase {
   uint16_t skipped_actions;
   uint16_t msgs_created;
   td::Bits256 action_list_hash;
-  StorageUsedShort tot_msg_size;
+  StorageUsed tot_msg_size;
 };
 
 struct TrBouncePhase_negfunds {
 };
 
 struct TrBouncePhase_nofunds {
-  StorageUsedShort msg_size;
+  StorageUsed msg_size;
   uint64_t req_fwd_fees;
 };
 
 struct TrBouncePhase_ok {
-  StorageUsedShort msg_size;
+  StorageUsed msg_size;
   uint64_t msg_fees;
   uint64_t fwd_fees;
 };


### PR DESCRIPTION
…tgres-v2 target and also add -DBUILD_SHARED_LIBS=off to manual instructions

Without this the instructions and script doesn't work.
Is this how it should be?
I saw that in the dockerfile everything is built with `make` and installed but `ton-index-postgres-v2` should be enough to setup the `ton-index-worker` right?