### PR TITLE
Implement measuring statistics

### DIFF
--- a/celldb-migrate/CMakeLists.txt
+++ b/celldb-migrate/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(celldb-migrate
 target_include_directories(celldb-migrate
     PUBLIC src
 )
-target_compile_features(celldb-migrate PRIVATE cxx_std_17)
+target_compile_features(celldb-migrate PRIVATE cxx_std_20)
 target_link_libraries(celldb-migrate tondb-scanner)
 
 install(TARGETS celldb-migrate RUNTIME DESTINATION bin)

--- a/ton-index-clickhouse/CMakeLists.txt
+++ b/ton-index-clickhouse/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_directories(ton-index-clickhouse
     PUBLIC external/ton
     PUBLIC external/clickhouse-cpp
 )
-target_compile_features(ton-index-clickhouse PRIVATE cxx_std_17)
+target_compile_features(ton-index-clickhouse PRIVATE cxx_std_20)
 target_link_libraries(ton-index-clickhouse tondb-scanner overlay tdutils tdactor adnl tl_api dht ton_crypto
         catchain validatorsession validator-disk ton_validator validator-disk smc-envelope
         clickhouse-cpp-lib)

--- a/ton-index-postgres-v2/CMakeLists.txt
+++ b/ton-index-postgres-v2/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_directories(ton-index-postgres-v2
     PUBLIC external/libpqxx
 )
 
-target_compile_features(ton-index-postgres-v2 PRIVATE cxx_std_17)
+target_compile_features(ton-index-postgres-v2 PRIVATE cxx_std_20)
 target_link_libraries(ton-index-postgres-v2 tondb-scanner overlay tdutils tdactor adnl tl_api dht ton_crypto
         catchain validatorsession validator-disk ton_validator validator-disk smc-envelope pqxx)
 target_link_options(ton-index-postgres-v2 PUBLIC -rdynamic)

--- a/ton-index-postgres-v2/src/IndexScheduler.cpp
+++ b/ton-index-postgres-v2/src/IndexScheduler.cpp
@@ -5,6 +5,7 @@
 #include "BlockInterfacesDetector.h"
 #include "Statistics.h"
 #include "td/utils/filesystem.h"
+#include "common/delay.h"
 
 
 void IndexScheduler::start_up() {
@@ -48,12 +49,15 @@ void IndexScheduler::alarm() {
         next_print_stats_ = td::Timestamp::in(stats_timeout_);
     }
     if (next_statistics_flush_.is_in_past()) {
-        auto stats = g_statistics.generate_report_and_reset();
-        auto path = working_dir_ + "/" + "statistics.txt";
-        auto status = td::atomic_write_file(path, std::move(stats));
-        if (status.is_error()) {
-            LOG(ERROR) << "Failed to write statistics to " << path << ": " << status.error();
-        }
+        ton::delay_action([working_dir = this->working_dir_]() {
+            auto stats = g_statistics.generate_report_and_reset();
+            auto path = working_dir + "/" + "stats.txt";
+            auto status = td::atomic_write_file(path, std::move(stats));
+            if (status.is_error()) {
+                LOG(ERROR) << "Failed to write statistics to " << path << ": " << status.error();
+            }
+        }, td::Timestamp::now());
+        
         next_statistics_flush_ = td::Timestamp::in(60.0);
     }
 
@@ -156,6 +160,7 @@ void IndexScheduler::schedule_seqno(std::uint32_t mc_seqno) {
     LOG(DEBUG) << "Scheduled seqno " << mc_seqno;
 
     processing_seqnos_.insert(mc_seqno);
+    timers_[mc_seqno] = td::Timer();
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), mc_seqno](td::Result<MasterchainBlockDataState> R) {
         if (R.is_error()) {
             LOG(ERROR) << "Failed to fetch seqno " << mc_seqno << ": " << R.move_as_error();
@@ -238,12 +243,13 @@ void IndexScheduler::seqno_interfaces_processed(std::uint32_t mc_seqno, ParsedBl
 void IndexScheduler::seqno_actions_processed(std::uint32_t mc_seqno, ParsedBlockPtr parsed_block) {
     LOG(DEBUG) << "Actions processed for seqno " << mc_seqno;
 
-    auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), mc_seqno](td::Result<td::Unit> R) {
+    auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), mc_seqno, timer = td::Timer{}](td::Result<td::Unit> R) {
         if (R.is_error()) {
             LOG(ERROR) << "Failed to insert seqno " << mc_seqno << ": " << R.move_as_error();
             td::actor::send_closure(SelfId, &IndexScheduler::reschedule_seqno, mc_seqno);
             return;
         }
+        g_statistics.record_time(INSERT_SEQNO, timer.elapsed() * 1e3);
         td::actor::send_closure(SelfId, &IndexScheduler::seqno_inserted, mc_seqno, R.move_as_ok());
     });
     auto Q = td::PromiseCreator::lambda([SelfId = actor_id(this), mc_seqno](td::Result<QueueState> R){
@@ -292,6 +298,8 @@ void IndexScheduler::seqno_inserted(std::uint32_t mc_seqno, td::Unit result) {
     if (mc_seqno > last_indexed_seqno_) {
         last_indexed_seqno_ = mc_seqno;
     }
+    g_statistics.record_time(PROCESS_SEQNO, timers_[mc_seqno].elapsed() * 1e3);
+    timers_.erase(mc_seqno);
 }
 
 void IndexScheduler::schedule_next_seqnos() {

--- a/ton-index-postgres-v2/src/IndexScheduler.h
+++ b/ton-index-postgres-v2/src/IndexScheduler.h
@@ -44,6 +44,8 @@ private:
   std::int32_t stats_timeout_{10};
   td::Timestamp next_print_stats_;
   td::Timestamp next_statistics_flush_;
+
+  std::unordered_map<ton::BlockSeqno, td::Timer> timers_;
 public:
   IndexScheduler(td::actor::ActorId<DbScanner> db_scanner, td::actor::ActorId<InsertManagerInterface> insert_manager,
       td::actor::ActorId<ParseManager> parse_manager, std::string working_dir, std::int32_t from_seqno = 0, std::int32_t to_seqno = 0, bool force_index = false,

--- a/ton-index-postgres-v2/src/IndexScheduler.h
+++ b/ton-index-postgres-v2/src/IndexScheduler.h
@@ -43,6 +43,7 @@ private:
 
   std::int32_t stats_timeout_{10};
   td::Timestamp next_print_stats_;
+  td::Timestamp next_statistics_flush_;
 public:
   IndexScheduler(td::actor::ActorId<DbScanner> db_scanner, td::actor::ActorId<InsertManagerInterface> insert_manager,
       td::actor::ActorId<ParseManager> parse_manager, std::string working_dir, std::int32_t from_seqno = 0, std::int32_t to_seqno = 0, bool force_index = false,

--- a/ton-index-postgres/CMakeLists.txt
+++ b/ton-index-postgres/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_directories(ton-index-postgres
     PUBLIC external/libpqxx
 )
 
-target_compile_features(ton-index-postgres PRIVATE cxx_std_17)
+target_compile_features(ton-index-postgres PRIVATE cxx_std_20)
 target_link_libraries(ton-index-postgres tondb-scanner overlay tdutils tdactor adnl tl_api dht ton_crypto
         catchain validatorsession validator-disk ton_validator validator-disk smc-envelope pqxx)
 target_link_options(ton-index-postgres PUBLIC -rdynamic)

--- a/ton-integrity-checker/CMakeLists.txt
+++ b/ton-integrity-checker/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_directories(ton-integrity-checker
     PUBLIC external/libpqxx
 )
 
-target_compile_features(ton-integrity-checker PRIVATE cxx_std_17)
+target_compile_features(ton-integrity-checker PRIVATE cxx_std_20)
 target_link_libraries(ton-integrity-checker tondb-scanner overlay tdutils tdactor adnl tl_api dht ton_crypto
         catchain validatorsession validator-disk ton_validator validator-disk smc-envelope pqxx)
 

--- a/ton-smc-scanner/CMakeLists.txt
+++ b/ton-smc-scanner/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_directories(ton-smc-scanner
     PUBLIC external/libpqxx
 )
 
-target_compile_features(ton-smc-scanner PRIVATE cxx_std_17)
+target_compile_features(ton-smc-scanner PRIVATE cxx_std_20)
 target_link_libraries(ton-smc-scanner tondb-scanner overlay tdutils tdactor adnl tl_api dht ton_crypto
         catchain validatorsession validator-disk ton_validator validator-disk smc-envelope pqxx)
 

--- a/ton-smc-scanner/src/SmcScanner.cpp
+++ b/ton-smc-scanner/src/SmcScanner.cpp
@@ -2,7 +2,7 @@
 #include "convert-utils.h"
 
 void SmcScanner::start_up() {
-    auto P = td::PromiseCreator::lambda([=, SelfId = actor_id(this)](td::Result<MasterchainBlockDataState> R){
+    auto P = td::PromiseCreator::lambda([=, this, SelfId = actor_id(this)](td::Result<MasterchainBlockDataState> R){
         if (R.is_error()) {
             LOG(ERROR) << "Failed to get seqno " << options_.seqno_ << ": " << R.move_as_error();
             stop();

--- a/ton-trace-emulator/CMakeLists.txt
+++ b/ton-trace-emulator/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_directories(ton-trace-emulator-core
     PUBLIC external/ton
 )
 target_link_libraries(ton-trace-emulator-core tondb-scanner overlay ton_validator emulator)
-target_compile_features(ton-trace-emulator-core PRIVATE cxx_std_17)
+target_compile_features(ton-trace-emulator-core PRIVATE cxx_std_20)
 
 add_executable(ton-trace-emulator
     src/main.cpp
@@ -37,7 +37,7 @@ target_link_directories(ton-trace-emulator
     PUBLIC external/redis-plus-plus
     PUBLIC external/msgpack-c
 )
-target_compile_features(ton-trace-emulator PRIVATE cxx_std_17)
+target_compile_features(ton-trace-emulator PRIVATE cxx_std_20)
 target_link_libraries(ton-trace-emulator ton_validator ton-trace-emulator-core hiredis redis++ msgpack-cxx)
 target_link_options(ton-trace-emulator PUBLIC -rdynamic)
 install(TARGETS ton-trace-emulator RUNTIME DESTINATION bin)

--- a/tondb-scanner/CMakeLists.txt
+++ b/tondb-scanner/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(tondb-scanner STATIC
     src/parse_token_data.cpp
     src/convert-utils.cpp
     src/tokens.cpp
+    src/Statistics.cpp
     src/smc-interfaces/Tokens.cpp
     src/smc-interfaces/NftSale.cpp
     src/smc-interfaces/execute-smc.cpp

--- a/tondb-scanner/CMakeLists.txt
+++ b/tondb-scanner/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_directories(tondb-scanner
     PUBLIC external/libpqxx
     PUBLIC external/msgpack-c
 )
-target_compile_features(tondb-scanner PRIVATE cxx_std_17)
+target_compile_features(tondb-scanner PRIVATE cxx_std_20)
 target_link_libraries(tondb-scanner overlay tdutils tdactor adnl tl_api dht
         catchain validatorsession validator-disk ton_validator validator-disk smc-envelope
         pqxx msgpack-cxx)

--- a/tondb-scanner/src/DataParser.cpp
+++ b/tondb-scanner/src/DataParser.cpp
@@ -15,8 +15,7 @@ using namespace ton::validator; //TODO: remove this
 void ParseQuery::start_up() {
   td::Timer timer;
   auto status = parse_impl();
-  timer.pause();
-  g_statistics.record_time("parse_query", timer.elapsed() * 1e3);
+  g_statistics.record_time(PARSE_SEQNO, timer.elapsed() * 1e3);
   
   if(status.is_error()) {
     promise_.set_error(status.move_as_error());
@@ -30,6 +29,7 @@ void ParseQuery::start_up() {
 td::Status ParseQuery::parse_impl() {
   td::optional<schema::Block> mc_block;
   for (auto &block_ds : mc_block_.shard_blocks_diff_) {
+    td::Timer timer;
     // common block info
     block::gen::Block::Record blk;
     block::gen::BlockInfo::Record info;
@@ -45,39 +45,46 @@ td::Status ParseQuery::parse_impl() {
     }
 
     // transactions and messages
+    td::Timer transactions_timer;
     std::map<td::Bits256, AccountStateShort> account_states_to_get;
     TRY_RESULT_ASSIGN(schema_block.transactions, parse_transactions(block_ds.block_data->block_id(), blk, info, extra, account_states_to_get));
+    g_statistics.record_time(PARSE_TRANSACTION, transactions_timer.elapsed() * 1e6, schema_block.transactions.size());
 
+    td::Timer acc_states_timer;
     TRY_RESULT(account_states_fast, parse_account_states_new(schema_block.workchain, schema_block.gen_utime, account_states_to_get));
+    g_statistics.record_time(PARSE_ACCOUNT_STATE, acc_states_timer.elapsed() * 1e6, account_states_fast.size());
     
     for (auto &acc : account_states_fast) {
-      result->account_states_.push_back(acc);
+      result->account_states_.push_back(std::move(acc));
     }
 
     // config
     if (block_ds.block_data->block_id().is_masterchain()) {
+      td::Timer config_timer;
       TRY_RESULT_ASSIGN(mc_block_.config_, block::ConfigInfo::extract_config(block_ds.block_state, block::ConfigInfo::needCapabilities | block::ConfigInfo::needLibraries));
+      g_statistics.record_time(PARSE_CONFIG, config_timer.elapsed() * 1e6);
     }
 
     result->blocks_.push_back(schema_block);
+    g_statistics.record_time(PARSE_BLOCK, timer.elapsed() * 1e3);
   }
 
   // shard details
-  for (auto &block_ds : mc_block_.shard_blocks_) {
+  for (const auto &block_ds : mc_block_.shard_blocks_) {
     auto shard_block = parse_shard_state(mc_block.value(), block_ds.block_data->block_id());
-    result->shard_state_.push_back(shard_block);
+    result->shard_state_.push_back(std::move(shard_block));
   }
 
   result->mc_block_ = mc_block_;
   return td::Status::OK();
 }
 
-schema::MasterchainBlockShard ParseQuery::parse_shard_state(schema::Block mc_block, const ton::BlockIdExt& shard_blk_id) {
+schema::MasterchainBlockShard ParseQuery::parse_shard_state(const schema::Block& mc_block, const ton::BlockIdExt& shard_blk_id) {
   return {mc_block.seqno, mc_block.start_lt, mc_block.gen_utime, shard_blk_id.id.workchain, static_cast<int64_t>(shard_blk_id.id.shard), shard_blk_id.id.seqno};
 }
 
 schema::Block ParseQuery::parse_block(const td::Ref<vm::Cell>& root_cell, const ton::BlockIdExt& blk_id, block::gen::Block::Record& blk, const block::gen::BlockInfo::Record& info, 
-                          const block::gen::BlockExtra::Record& extra, td::optional<schema::Block> &mc_block) {
+                          const block::gen::BlockExtra::Record& extra, const td::optional<schema::Block> &mc_block) {
   schema::Block block;
   block.workchain = blk_id.id.workchain;
   block.shard = static_cast<int64_t>(blk_id.id.shard);

--- a/tondb-scanner/src/DataParser.cpp
+++ b/tondb-scanner/src/DataParser.cpp
@@ -8,11 +8,16 @@
 #include "validator/interfaces/block.h"
 #include "validator/interfaces/shard.h"
 #include "convert-utils.h"
+#include "Statistics.h"
 
 using namespace ton::validator; //TODO: remove this
 
 void ParseQuery::start_up() {
+  td::Timer timer;
   auto status = parse_impl();
+  timer.pause();
+  g_statistics.record_time("parse_query", timer.elapsed() * 1e3);
+  
   if(status.is_error()) {
     promise_.set_error(status.move_as_error());
   }

--- a/tondb-scanner/src/DataParser.h
+++ b/tondb-scanner/src/DataParser.h
@@ -19,8 +19,8 @@ private:
   td::Status parse_impl();
 
   schema::Block parse_block(const td::Ref<vm::Cell>& root_cell, const ton::BlockIdExt& blk_id, block::gen::Block::Record& blk, const block::gen::BlockInfo::Record& info, 
-                            const block::gen::BlockExtra::Record& extra, td::optional<schema::Block> &mc_block);
-  schema::MasterchainBlockShard parse_shard_state(schema::Block mc_block, const ton::BlockIdExt& shard_blk_id);
+                            const block::gen::BlockExtra::Record& extra, const td::optional<schema::Block> &mc_block);
+  schema::MasterchainBlockShard parse_shard_state(const schema::Block& mc_block, const ton::BlockIdExt& shard_blk_id);
   static td::Result<schema::CurrencyCollection> parse_currency_collection(td::Ref<vm::CellSlice> csr);
   td::Result<schema::Message> parse_message(td::Ref<vm::Cell> msg_cell);
   td::Result<schema::TrStoragePhase> parse_tr_storage_phase(vm::CellSlice& cs);

--- a/tondb-scanner/src/Statistics.cpp
+++ b/tondb-scanner/src/Statistics.cpp
@@ -1,51 +1,8 @@
 #include "Statistics.h"
+#include <iomanip>
 
-HistogramBucketMapper::HistogramBucketMapper() {
-  // If you change this, you also need to change
-  // size of array buckets_ in HistogramImpl
-  bucketValues_ = {1, 2};
-  double bucket_val = static_cast<double>(bucketValues_.back());
-  while ((bucket_val = 1.5 * bucket_val) <=
-         static_cast<double>(std::numeric_limits<uint64_t>::max())) {
-    bucketValues_.push_back(static_cast<uint64_t>(bucket_val));
-    // Extracts two most significant digits to make histogram buckets more
-    // human-readable. E.g., 172 becomes 170.
-    uint64_t pow_of_ten = 1;
-    while (bucketValues_.back() / 10 > 10) {
-      bucketValues_.back() /= 10;
-      pow_of_ten *= 10;
-    }
-    bucketValues_.back() *= pow_of_ten;
-  }
-  maxBucketValue_ = bucketValues_.back();
-  minBucketValue_ = bucketValues_.front();
-}
 
-size_t HistogramBucketMapper::IndexForValue(const uint64_t value) const {
-  auto beg = bucketValues_.begin();
-  auto end = bucketValues_.end();
-  if (value >= maxBucketValue_)
-    return end - beg - 1;  // bucketValues_.size() - 1
-  else
-    return std::lower_bound(beg, end, value) - beg;
-}
-
-namespace {
-const HistogramBucketMapper bucketMapper;
-}
-
-void CountMetric::add(uint64_t delta) {
-    count_.fetch_add(delta, std::memory_order_relaxed);
-}
-
-uint64_t CountMetric::get() const {
-    return count_.load(std::memory_order_relaxed);
-}
-
-TimingMetric::TimingMetric(): num_buckets_(bucketMapper.BucketCount()) {
-}
-
-void TimingMetric::add(uint64_t duration) {
+void HistogramImpl::add(uint64_t duration) {
     count_.fetch_add(1, std::memory_order_relaxed);
     sum_.fetch_add(duration, std::memory_order_relaxed);
     update_max(max_, duration);
@@ -54,15 +11,16 @@ void TimingMetric::add(uint64_t duration) {
     buckets_[index].fetch_add(1, std::memory_order_relaxed);
 }
 
-uint64_t TimingMetric::get_count() const {
+uint64_t HistogramImpl::get_count() const {
     return count_.load(std::memory_order_relaxed);
 }
 
-uint64_t TimingMetric::get_sum() const {
+uint64_t HistogramImpl::get_sum() const {
     return sum_.load(std::memory_order_relaxed);
 }
 
-double TimingMetric::compute_percentile(double percentile) const {
+double HistogramImpl::compute_percentile(double percentile) const {
+    std::lock_guard<std::mutex> lock(mutex_);
     uint64_t total = get_count();
     if (total == 0) return 0.0;
 
@@ -70,7 +28,7 @@ double TimingMetric::compute_percentile(double percentile) const {
     uint64_t accumulated = 0;
     size_t bucket_idx = 0;
 
-    for (; bucket_idx < num_buckets_; ++bucket_idx) {
+    for (; bucket_idx < bucketCount(); ++bucket_idx) {
         uint64_t bucket_count = buckets_[bucket_idx].load(std::memory_order_relaxed);
         if (accumulated + bucket_count >= threshold) break;
         accumulated += bucket_count;
@@ -79,12 +37,17 @@ double TimingMetric::compute_percentile(double percentile) const {
     uint64_t lower = 0, upper = 0;
     if (bucket_idx == 0) {
         upper = bucketMapper.FirstValue();
-    } else if (bucket_idx < num_buckets_) {
+    } else if (bucket_idx < bucketCount()) {
         lower = bucketMapper.BucketLimit(bucket_idx - 1) + 1;
         upper = bucketMapper.BucketLimit(bucket_idx);
     } else {
         lower = bucketMapper.LastValue() + 1;
         upper = max_.load(std::memory_order_relaxed);
+    }
+
+    uint64_t actual_max = max_.load(std::memory_order_relaxed);
+    if (upper > actual_max) {
+        upper = actual_max;
     }
 
     uint64_t bucket_count = buckets_[bucket_idx].load(std::memory_order_relaxed);
@@ -94,95 +57,91 @@ double TimingMetric::compute_percentile(double percentile) const {
     return lower + fraction * (upper - lower);
 }
 
-uint64_t TimingMetric::get_max() const {
+uint64_t HistogramImpl::get_max() const {
     return max_.load(std::memory_order_relaxed);
 }
 
-size_t TimingMetric::find_bucket(uint64_t value) const {
-    for (size_t i = 0; i < num_buckets_; ++i) {
-        if (value <= bucketMapper.BucketLimit(i)) return i;
+void HistogramImpl::merge(const HistogramImpl &other) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    count_.fetch_add(other.count_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    sum_.fetch_add(other.sum_.load(std::memory_order_relaxed), std::memory_order_relaxed);
+    update_max(max_, other.max_.load(std::memory_order_relaxed));
+    update_min(min_, other.min_.load(std::memory_order_relaxed));
+
+    for (size_t i = 0; i < bucketCount(); ++i) {
+        buckets_[i].fetch_add(other.buckets_[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
     }
-    return num_buckets_ - 1;
 }
 
-void TimingMetric::update_max(std::atomic<uint64_t>& max, uint64_t value) {
+void HistogramImpl::reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    count_.store(0, std::memory_order_relaxed);
+    sum_.store(0, std::memory_order_relaxed);
+    max_.store(0, std::memory_order_relaxed);
+    min_.store(0, std::memory_order_relaxed);
+
+    for (size_t i = 0; i < bucketCount(); ++i) {
+        buckets_[i].store(0, std::memory_order_relaxed);
+    }
+}
+
+void HistogramImpl::update_max(std::atomic<uint64_t>& max, uint64_t value) {
     uint64_t current = max.load(std::memory_order_relaxed);
     while (value > current && !max.compare_exchange_weak(current, value, std::memory_order_relaxed));
 }
 
-void Statistics::record_time(const std::string& name, uint64_t duration, uint32_t count) {
+void HistogramImpl::update_min(std::atomic<uint64_t>& min, uint64_t value) {
+    uint64_t current = min.load(std::memory_order_relaxed);
+    while (value < current && !min.compare_exchange_weak(current, value, std::memory_order_relaxed));
+}
+
+void Statistics::record_time(Histogram hist, uint64_t duration, uint32_t count) {
     if (count > 1) {
-        // for multiple events, we average the duration
+        // for batch events, we average the duration
         duration /= count;
     }
-    std::shared_lock lock(timings_mutex_);
-    auto it = timing_metrics_.find(name);
-    if (it != timing_metrics_.end()) {
-        it->second->add(duration);
-        return;
-    }
-    lock.unlock();
-
-    std::unique_lock ulock(timings_mutex_);
-    it = timing_metrics_.find(name);
-    if (it != timing_metrics_.end()) {
-        it->second->add(duration);
-        return;
-    }
-
-    auto metric = std::make_unique<TimingMetric>();
-    metric->add(duration);
-    timing_metrics_[name] = std::move(metric);
+    per_core_stats_.get().histograms_[hist].add(duration);
 }
 
-void Statistics::record_count(const std::string& name, uint64_t delta) {
-    std::shared_lock lock(counts_mutex_);
-    auto it = count_metrics_.find(name);
-    if (it != count_metrics_.end()) {
-        it->second->add(delta);
-        return;
-    }
-    lock.unlock();
-
-    std::unique_lock ulock(counts_mutex_);
-    it = count_metrics_.find(name);
-    if (it != count_metrics_.end()) {
-        it->second->add(delta);
-        return;
-    }
-
-    auto metric = std::make_unique<CountMetric>();
-    metric->add(delta);
-    count_metrics_[name] = std::move(metric);
+void Statistics::record_count(Ticker ticker, uint64_t count) {
+    per_core_stats_.get().tickers_[ticker].fetch_add(count, std::memory_order_relaxed);
 }
 
-std::string Statistics::generate_report_and_reset() const {
-    std::unique_lock timings_lock(timings_mutex_);
-    auto&& timing_metrics = std::move(timing_metrics_);
-    timings_lock.unlock();
-    std::unique_lock counts_lock(counts_mutex_);
-    auto&& count_metrics = std::move(count_metrics_);
-    counts_lock.unlock();
+std::string Statistics::generate_report_and_reset() {
+  std::array<uint64_t, TICKERS_COUNT> aggTickers = {};
+  std::array<HistogramImpl, HISTOGRAMS_COUNT> aggHist;
 
-    std::ostringstream oss;
-
-    for (const auto& [name, metric] : timing_metrics) {
-        uint64_t count = metric->get_count();
-        uint64_t sum = metric->get_sum();
-        double p50 = metric->compute_percentile(50.0);
-        double p95 = metric->compute_percentile(95.0);
-        double p99 = metric->compute_percentile(99.0);
-        uint64_t p100 = metric->get_max();
-
-        oss << name << " P50 : " << p50 << " P95 : " << p95 << " P99 : " << p99 << " P100 : " << p100
-            << " COUNT : " << count << " SUM : " << sum << std::endl;
+  per_core_stats_.for_each([&](StatisticsData &data) {
+    // Merge tickers.
+    for (uint32_t i = 0; i < TICKERS_COUNT; ++i) {
+      uint64_t value = data.tickers_[i].load(std::memory_order_relaxed);
+      aggTickers[i] += value;
+      data.tickers_[i].store(0, std::memory_order_relaxed);
     }
 
-    for (const auto& [name, metric] : count_metrics) {
-        oss << name << " COUNT : " << metric->get() << std::endl;
+    // Merge histograms.
+    for (uint32_t h = 0; h < HISTOGRAMS_COUNT; ++h) {
+      aggHist[h].merge(data.histograms_[h]);
+      data.histograms_[h].reset();
     }
+  });
 
-    return oss.str();
+  std::ostringstream oss;
+  oss << std::setprecision(3) << std::fixed;
+  for (uint32_t i = 0; i < TICKERS_COUNT; ++i) {
+    oss << ticker_names.at(i) << " COUNT : " << aggTickers[i] << std::endl;
+  }
+
+  for (uint32_t h = 0; h < HISTOGRAMS_COUNT; ++h) {
+    oss << histogram_names.at(h) << " P50 : " << aggHist[h].compute_percentile(50.0)
+                                 << " P95 : " << aggHist[h].compute_percentile(95.0)
+                                 << " P99 : " << aggHist[h].compute_percentile(99.0)
+                                 << " P100 : " << aggHist[h].get_max()
+                                 << " COUNT : " << aggHist[h].get_count()
+                                 << " SUM : " << aggHist[h].get_sum() << std::endl;
+  }
+
+  return oss.str();
 }
 
 Statistics g_statistics;

--- a/tondb-scanner/src/Statistics.cpp
+++ b/tondb-scanner/src/Statistics.cpp
@@ -1,0 +1,188 @@
+#include "Statistics.h"
+
+HistogramBucketMapper::HistogramBucketMapper() {
+  // If you change this, you also need to change
+  // size of array buckets_ in HistogramImpl
+  bucketValues_ = {1, 2};
+  double bucket_val = static_cast<double>(bucketValues_.back());
+  while ((bucket_val = 1.5 * bucket_val) <=
+         static_cast<double>(std::numeric_limits<uint64_t>::max())) {
+    bucketValues_.push_back(static_cast<uint64_t>(bucket_val));
+    // Extracts two most significant digits to make histogram buckets more
+    // human-readable. E.g., 172 becomes 170.
+    uint64_t pow_of_ten = 1;
+    while (bucketValues_.back() / 10 > 10) {
+      bucketValues_.back() /= 10;
+      pow_of_ten *= 10;
+    }
+    bucketValues_.back() *= pow_of_ten;
+  }
+  maxBucketValue_ = bucketValues_.back();
+  minBucketValue_ = bucketValues_.front();
+}
+
+size_t HistogramBucketMapper::IndexForValue(const uint64_t value) const {
+  auto beg = bucketValues_.begin();
+  auto end = bucketValues_.end();
+  if (value >= maxBucketValue_)
+    return end - beg - 1;  // bucketValues_.size() - 1
+  else
+    return std::lower_bound(beg, end, value) - beg;
+}
+
+namespace {
+const HistogramBucketMapper bucketMapper;
+}
+
+void CountMetric::add(uint64_t delta) {
+    count_.fetch_add(delta, std::memory_order_relaxed);
+}
+
+uint64_t CountMetric::get() const {
+    return count_.load(std::memory_order_relaxed);
+}
+
+TimingMetric::TimingMetric(): num_buckets_(bucketMapper.BucketCount()) {
+}
+
+void TimingMetric::add(uint64_t duration) {
+    count_.fetch_add(1, std::memory_order_relaxed);
+    sum_.fetch_add(duration, std::memory_order_relaxed);
+    update_max(max_, duration);
+
+    size_t index = bucketMapper.IndexForValue(duration);
+    buckets_[index].fetch_add(1, std::memory_order_relaxed);
+}
+
+uint64_t TimingMetric::get_count() const {
+    return count_.load(std::memory_order_relaxed);
+}
+
+uint64_t TimingMetric::get_sum() const {
+    return sum_.load(std::memory_order_relaxed);
+}
+
+double TimingMetric::compute_percentile(double percentile) const {
+    uint64_t total = get_count();
+    if (total == 0) return 0.0;
+
+    double threshold = total * (percentile / 100.0);
+    uint64_t accumulated = 0;
+    size_t bucket_idx = 0;
+
+    for (; bucket_idx < num_buckets_; ++bucket_idx) {
+        uint64_t bucket_count = buckets_[bucket_idx].load(std::memory_order_relaxed);
+        if (accumulated + bucket_count >= threshold) break;
+        accumulated += bucket_count;
+    }
+
+    uint64_t lower = 0, upper = 0;
+    if (bucket_idx == 0) {
+        upper = bucketMapper.FirstValue();
+    } else if (bucket_idx < num_buckets_) {
+        lower = bucketMapper.BucketLimit(bucket_idx - 1) + 1;
+        upper = bucketMapper.BucketLimit(bucket_idx);
+    } else {
+        lower = bucketMapper.LastValue() + 1;
+        upper = max_.load(std::memory_order_relaxed);
+    }
+
+    uint64_t bucket_count = buckets_[bucket_idx].load(std::memory_order_relaxed);
+    if (bucket_count == 0) return upper;
+
+    double fraction = (threshold - accumulated) / bucket_count;
+    return lower + fraction * (upper - lower);
+}
+
+uint64_t TimingMetric::get_max() const {
+    return max_.load(std::memory_order_relaxed);
+}
+
+size_t TimingMetric::find_bucket(uint64_t value) const {
+    for (size_t i = 0; i < num_buckets_; ++i) {
+        if (value <= bucketMapper.BucketLimit(i)) return i;
+    }
+    return num_buckets_ - 1;
+}
+
+void TimingMetric::update_max(std::atomic<uint64_t>& max, uint64_t value) {
+    uint64_t current = max.load(std::memory_order_relaxed);
+    while (value > current && !max.compare_exchange_weak(current, value, std::memory_order_relaxed));
+}
+
+void Statistics::record_time(const std::string& name, uint64_t duration, uint32_t count) {
+    if (count > 1) {
+        // for multiple events, we average the duration
+        duration /= count;
+    }
+    std::shared_lock lock(timings_mutex_);
+    auto it = timing_metrics_.find(name);
+    if (it != timing_metrics_.end()) {
+        it->second->add(duration);
+        return;
+    }
+    lock.unlock();
+
+    std::unique_lock ulock(timings_mutex_);
+    it = timing_metrics_.find(name);
+    if (it != timing_metrics_.end()) {
+        it->second->add(duration);
+        return;
+    }
+
+    auto metric = std::make_unique<TimingMetric>();
+    metric->add(duration);
+    timing_metrics_[name] = std::move(metric);
+}
+
+void Statistics::record_count(const std::string& name, uint64_t delta) {
+    std::shared_lock lock(counts_mutex_);
+    auto it = count_metrics_.find(name);
+    if (it != count_metrics_.end()) {
+        it->second->add(delta);
+        return;
+    }
+    lock.unlock();
+
+    std::unique_lock ulock(counts_mutex_);
+    it = count_metrics_.find(name);
+    if (it != count_metrics_.end()) {
+        it->second->add(delta);
+        return;
+    }
+
+    auto metric = std::make_unique<CountMetric>();
+    metric->add(delta);
+    count_metrics_[name] = std::move(metric);
+}
+
+std::string Statistics::generate_report_and_reset() const {
+    std::unique_lock timings_lock(timings_mutex_);
+    auto&& timing_metrics = std::move(timing_metrics_);
+    timings_lock.unlock();
+    std::unique_lock counts_lock(counts_mutex_);
+    auto&& count_metrics = std::move(count_metrics_);
+    counts_lock.unlock();
+
+    std::ostringstream oss;
+
+    for (const auto& [name, metric] : timing_metrics) {
+        uint64_t count = metric->get_count();
+        uint64_t sum = metric->get_sum();
+        double p50 = metric->compute_percentile(50.0);
+        double p95 = metric->compute_percentile(95.0);
+        double p99 = metric->compute_percentile(99.0);
+        uint64_t p100 = metric->get_max();
+
+        oss << name << " P50 : " << p50 << " P95 : " << p95 << " P99 : " << p99 << " P100 : " << p100
+            << " COUNT : " << count << " SUM : " << sum << std::endl;
+    }
+
+    for (const auto& [name, metric] : count_metrics) {
+        oss << name << " COUNT : " << metric->get() << std::endl;
+    }
+
+    return oss.str();
+}
+
+Statistics g_statistics;

--- a/tondb-scanner/src/Statistics.h
+++ b/tondb-scanner/src/Statistics.h
@@ -1,0 +1,83 @@
+#include <atomic>
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <mutex>
+#include <memory>
+#include <shared_mutex>
+#include <algorithm>
+#include <cstdio>
+#include <sstream>
+#include "td/utils/ThreadLocalStorage.h"
+
+class HistogramBucketMapper {
+ public:
+  HistogramBucketMapper();
+
+  // converts a value to the bucket index.
+  size_t IndexForValue(uint64_t value) const;
+  // number of buckets required.
+
+  size_t BucketCount() const { return bucketValues_.size(); }
+  uint64_t LastValue() const { return maxBucketValue_; }
+  uint64_t FirstValue() const { return minBucketValue_; }
+
+  uint64_t BucketLimit(const size_t bucketNumber) const {
+    // assert(bucketNumber < BucketCount());
+    return bucketValues_[bucketNumber];
+  }
+
+ private:
+  std::vector<uint64_t> bucketValues_;
+  uint64_t maxBucketValue_;
+  uint64_t minBucketValue_;
+};
+
+class CountMetric {
+public:
+    void add(uint64_t delta);
+    uint64_t get() const;
+
+private:
+    std::atomic<uint64_t> count_{0};
+};
+
+class TimingMetric {
+public:
+    TimingMetric();
+    void add(uint64_t duration);
+    uint64_t get_count() const;
+    uint64_t get_sum() const;
+    double compute_percentile(double percentile) const;
+    uint64_t get_max() const;
+
+private:
+    std::atomic<uint64_t> count_{0};
+    std::atomic<uint64_t> sum_{0};
+    std::atomic<uint64_t> max_{0};
+    std::vector<uint64_t> bucket_limits_;
+    std::atomic<uint64_t> buckets_[109]; // == HistogramBucketMapper::BucketCount(). TODO: move to constexpr with cpp20
+    size_t num_buckets_;
+
+    size_t find_bucket(uint64_t value) const;
+
+    static void update_max(std::atomic<uint64_t>& max, uint64_t value);
+};
+
+size_t METRICS_COMMON[] = {1, 2};
+
+class Statistics {
+public:
+    void record_time(const std::string& name, uint64_t duration, uint32_t count = 1);
+    void record_count(const std::string& name, uint64_t delta);
+    std::string generate_report_and_reset() const;
+
+private:
+    mutable std::shared_mutex timings_mutex_;
+    std::unordered_map<std::string, std::unique_ptr<TimingMetric>> timing_metrics_;
+
+    mutable std::shared_mutex counts_mutex_;
+    std::unordered_map<std::string, std::unique_ptr<CountMetric>> count_metrics_;
+};
+
+extern Statistics g_statistics;

--- a/tondb-scanner/src/Statistics.h
+++ b/tondb-scanner/src/Statistics.h
@@ -1,83 +1,163 @@
+#pragma once
 #include <atomic>
 #include <vector>
-#include <string>
 #include <unordered_map>
 #include <mutex>
-#include <memory>
-#include <shared_mutex>
-#include <algorithm>
-#include <cstdio>
-#include <sstream>
+#include <new>
+#include <cassert>
 #include "td/utils/ThreadLocalStorage.h"
 
-class HistogramBucketMapper {
- public:
-  HistogramBucketMapper();
+constexpr size_t bucketCount() { 
+  size_t count = 2; // 1 and 2
+  double bucket_val = 2.0;
+  constexpr double max = static_cast<double>(std::numeric_limits<uint64_t>::max());
+  while ((bucket_val = 1.5 * bucket_val) <= max) {
+    ++count;
+  }
+  return count;
+};
 
-  // converts a value to the bucket index.
-  size_t IndexForValue(uint64_t value) const;
-  // number of buckets required.
+consteval auto bucketValues() {
+  std::array<uint64_t, bucketCount()> bucketValues;
+  bucketValues[0] = 1;
+  bucketValues[1] = 2;
+  size_t i = 1;
+  double bucket_val = static_cast<double>(bucketValues[i++]);
+  constexpr double max = static_cast<double>(std::numeric_limits<uint64_t>::max());
+  while ((bucket_val = 1.5 * bucket_val) <= max) {
+    bucketValues[i++] = static_cast<uint64_t>(bucket_val);
+  }
+  if (bucketCount() != i) {
+    throw "bucketValues() does not match bucketCount()";
+  }
+  return bucketValues;
+}
 
-  size_t BucketCount() const { return bucketValues_.size(); }
-  uint64_t LastValue() const { return maxBucketValue_; }
-  uint64_t FirstValue() const { return minBucketValue_; }
+class HistogramBucketMapper
+{
+public:
+  consteval HistogramBucketMapper() : bucketValues_(bucketValues()) {}
+
+  size_t IndexForValue(const uint64_t value) const {
+    auto beg = bucketValues_.begin();
+    auto end = bucketValues_.end();
+    if (value >= LastValue())
+      return end - beg - 1; // bucketValues_.size() - 1
+    else
+      return std::lower_bound(beg, end, value) - beg;
+  }
+
+  constexpr uint64_t LastValue() const { return bucketValues_.back(); }
+  constexpr uint64_t FirstValue() const { return bucketValues_.front(); }
+  constexpr uint64_t BucketCount() const { return bucketValues_.size(); }
 
   uint64_t BucketLimit(const size_t bucketNumber) const {
-    // assert(bucketNumber < BucketCount());
+    assert(bucketNumber < BucketCount());
     return bucketValues_[bucketNumber];
   }
 
- private:
-  std::vector<uint64_t> bucketValues_;
-  uint64_t maxBucketValue_;
-  uint64_t minBucketValue_;
+private:
+  std::result_of<decltype(&bucketValues)()>::type bucketValues_;
 };
 
-class CountMetric {
+constexpr HistogramBucketMapper bucketMapper;
+
+class HistogramImpl {
 public:
-    void add(uint64_t delta);
-    uint64_t get() const;
+  HistogramImpl() = default;
+  void add(uint64_t duration);
+  uint64_t get_count() const;
+  uint64_t get_sum() const;
+  double compute_percentile(double percentile) const;
+  uint64_t get_max() const;
+  void merge(const HistogramImpl &other);
+  void reset();
 
 private:
-    std::atomic<uint64_t> count_{0};
+  std::atomic<uint64_t> count_{0};
+  std::atomic<uint64_t> sum_{0};
+  std::atomic<uint64_t> min_{0};
+  std::atomic<uint64_t> max_{0};
+  std::vector<uint64_t> bucket_limits_;
+  std::atomic<uint64_t> buckets_[bucketCount()];
+  mutable std::mutex mutex_;
+
+  static void update_max(std::atomic<uint64_t> &max, uint64_t value);
+  static void update_min(std::atomic<uint64_t> &min, uint64_t value);
 };
 
-class TimingMetric {
-public:
-    TimingMetric();
-    void add(uint64_t duration);
-    uint64_t get_count() const;
-    uint64_t get_sum() const;
-    double compute_percentile(double percentile) const;
-    uint64_t get_max() const;
-
-private:
-    std::atomic<uint64_t> count_{0};
-    std::atomic<uint64_t> sum_{0};
-    std::atomic<uint64_t> max_{0};
-    std::vector<uint64_t> bucket_limits_;
-    std::atomic<uint64_t> buckets_[109]; // == HistogramBucketMapper::BucketCount(). TODO: move to constexpr with cpp20
-    size_t num_buckets_;
-
-    size_t find_bucket(uint64_t value) const;
-
-    static void update_max(std::atomic<uint64_t>& max, uint64_t value);
+enum Ticker : uint32_t {
+  SEQNO_FETCH_ERROR = 0,
+  INSERT_CONFLICT,
+  TICKERS_COUNT
 };
 
-size_t METRICS_COMMON[] = {1, 2};
+enum Histogram : uint32_t {
+  PROCESS_SEQNO = 0,
+
+  CATCH_UP_WITH_PRIMARY,
+  FETCH_SEQNO,
+  
+  PARSE_SEQNO,
+  PARSE_BLOCK,
+  PARSE_TRANSACTION,
+  PARSE_ACCOUNT_STATE,
+  PARSE_CONFIG,
+  
+  TRACE_ASSEMBLER_GC_STATE,
+  TRACE_ASSEMBLER_SAVE_STATE,
+  TRACE_ASSEMBLER_PROCESS_BLOCK,
+
+  DETECT_INTERFACES_SEQNO,
+  DETECT_ACTIONS_SEQNO,
+
+  INSERT_SEQNO,
+  INSERT_BATCH_CONNECT,
+  INSERT_BATCH_EXEC_DATA,
+  INSERT_BATCH_EXEC_STATES,
+  INSERT_BATCH_COMMIT,
+  
+  HISTOGRAMS_COUNT
+};
+
+const std::unordered_map<uint32_t, std::string_view> ticker_names = {
+    {SEQNO_FETCH_ERROR, "indexer.seqno.fetch.error"},
+    {INSERT_CONFLICT, "indexer.insert.conflict"},
+};
+const std::unordered_map<uint32_t, std::string_view> histogram_names = {
+    {PROCESS_SEQNO, "indexer.index.seqno.millis"},
+    {CATCH_UP_WITH_PRIMARY, "indexer.catch_up_with_primary.millis"},
+    {FETCH_SEQNO, "indexer.fetch.seqno.millis"},
+    {PARSE_SEQNO, "indexer.parse.seqno.millis"},
+    {PARSE_BLOCK, "indexer.parse.block.millis"},
+    {PARSE_TRANSACTION, "indexer.parse.transaction.micros"},
+    {PARSE_ACCOUNT_STATE, "indexer.parse.account_state.micros"},
+    {PARSE_CONFIG, "indexer.parse.config.micros"},
+    {TRACE_ASSEMBLER_GC_STATE, "indexer.traceassembler.gc_state.micros"},
+    {TRACE_ASSEMBLER_SAVE_STATE, "indexer.traceassembler.save_state.micros"},
+    {TRACE_ASSEMBLER_PROCESS_BLOCK, "indexer.traceassembler.process_block.micros"},
+    {DETECT_INTERFACES_SEQNO, "indexer.interfaces.seqno.millis"},
+    {DETECT_ACTIONS_SEQNO, "indexer.actions.seqno.micros"},
+    {INSERT_SEQNO, "indexer.insert.seqno.millis"},
+    {INSERT_BATCH_CONNECT, "indexer.insert.batch.connect.millis"},
+    {INSERT_BATCH_EXEC_DATA, "indexer.insert.batch.exec_data.millis"},
+    {INSERT_BATCH_EXEC_STATES, "indexer.insert.batch.exec_states.millis"},
+    {INSERT_BATCH_COMMIT, "indexer.insert.batch.commit.millis"},
+};
 
 class Statistics {
 public:
-    void record_time(const std::string& name, uint64_t duration, uint32_t count = 1);
-    void record_count(const std::string& name, uint64_t delta);
-    std::string generate_report_and_reset() const;
+  void record_time(Histogram hist, uint64_t duration, uint32_t count = 1);
+  void record_count(Ticker ticker, uint64_t count = 1);
+  std::string generate_report_and_reset();
 
 private:
-    mutable std::shared_mutex timings_mutex_;
-    std::unordered_map<std::string, std::unique_ptr<TimingMetric>> timing_metrics_;
+  struct StatisticsData {
+    std::atomic_uint_fast64_t tickers_[TICKERS_COUNT] = {{0}};
+    HistogramImpl histograms_[HISTOGRAMS_COUNT];
+  };
 
-    mutable std::shared_mutex counts_mutex_;
-    std::unordered_map<std::string, std::unique_ptr<CountMetric>> count_metrics_;
+  td::ThreadLocalStorage<StatisticsData> per_core_stats_;
 };
 
 extern Statistics g_statistics;

--- a/tondb-scanner/src/smc-interfaces/Tokens.cpp
+++ b/tondb-scanner/src/smc-interfaces/Tokens.cpp
@@ -126,7 +126,7 @@ void JettonWalletDetectorR::start_up() {
     data.mintless_is_claimed = std::nullopt;
   }
 
-  auto R = td::PromiseCreator::lambda([=, SelfId = actor_id(this)](td::Result<schema::AccountState> account_state_r) mutable {
+  auto R = td::PromiseCreator::lambda([=, this, SelfId = actor_id(this)](td::Result<schema::AccountState> account_state_r) mutable {
     if (account_state_r.is_error()) {
       promise_.set_error(account_state_r.move_as_error());
       stop();
@@ -302,7 +302,7 @@ void NftItemDetectorR::start_up() {
     stop();
   } else {
     auto ind_content = stack[4].as_cell();
-    auto R = td::PromiseCreator::lambda([=, SelfId = actor_id(this)](td::Result<schema::AccountState> account_state_r) mutable {
+    auto R = td::PromiseCreator::lambda([=, this, SelfId = actor_id(this)](td::Result<schema::AccountState> account_state_r) mutable {
       if (account_state_r.is_error()) {
         promise_.set_error(account_state_r.move_as_error());
         stop();


### PR DESCRIPTION
To make Statistics class as lock-free as possible they are aggregated on each thread into thread local separate set of histograms/counters. Per request they are merged and dumped to string.
To enable constexpr buckets calculation we need c++20.