### PR TITLE
Fix the misplacement of compute phase's gas_fees and gas_used value.

### DIFF
--- a/ton-index-postgres-v2/src/InsertManagerPostgres.cpp
+++ b/ton-index-postgres-v2/src/InsertManagerPostgres.cpp
@@ -614,7 +614,7 @@ void InsertBatchPostgres::insert_transactions(pqxx::work &txn, bool with_copy) {
                 std::nullopt, std::nullopt};
       } else if constexpr (std::is_same_v<T, schema::TrComputePhase_vm>) {
         return {false, std::nullopt, arg.success, arg.msg_state_used, arg.account_activated, 
-                arg.gas_used, arg.gas_fees, arg.gas_limit, arg.gas_credit, 
+                arg.gas_fees, arg.gas_used, arg.gas_limit, arg.gas_credit, 
                 arg.mode, arg.exit_code, arg.exit_arg, arg.vm_steps, 
                 arg.vm_init_state_hash, arg.vm_final_state_hash};
       } else {


### PR DESCRIPTION
Hello everyone 😀👋

I find that new version of ton-index-worker's `ton-index-postgres-v2` does incorrect value assignment in the transaction compute phase. So the result record stored in the PostgreSQL database is also not correct neither.

For example, the transaction hash `y+oFJH1UVsx2+HCUBmEG61PfWrhawML1q1k0Hf/iNxw=` at the mainnet should have gas usage `9289` and gas fee 0.0037156 TON (i.e., 3715600 nanotons) ([reference](https://explorer.toncoin.org/transaction?account=0:6bebcc2448012bba42e151f5d140448cf7be8e22a2233d8da3a1423bdc244aac&lt=55338135000004&hash=cbea05247d5456cc76f87094066106eb53df5ab85ac0c2f5ab59341dffe2371c)).

However, in the TonCenter website, I got the reversed result of these two numbers. (see the snapshot below or the [URL](https://toncenter.com/api/v3/transactions?hash=y%2BoFJH1UVsx2%2BHCUBmEG61PfWrhawML1q1k0Hf%2FiNxw%3D))

![圖片](https://github.com/user-attachments/assets/6d2be758-57eb-44ad-bb11-417d590d16c0)